### PR TITLE
Centralize dependency management in buildSrc

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,16 +48,17 @@ android {
 
 dependencies {
     // Android
-    implementation("androidx.core:core-ktx:1.9.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
-    implementation("androidx.activity:activity-compose:1.7.0")
+    implementation(`androidx-core-ktx`())
+    implementation(`androidx-lifecycle-runtime-ktx`())
+    implementation(`androidx-activity-compose`())
 
     // Compose
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
-    implementation("androidx.compose.ui:ui")
-    implementation("androidx.compose.ui:ui-graphics")
-    implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material3:material3")
+    implementation(platform(`androidx-compose-bom`()))
+    implementation(`androidx-compose-ui`())
+    implementation(`androidx-compose-ui-graphics`())
+    implementation(`androidx-compose-ui-tooling-preview`())
+    implementation(`androidx-compose-material3`())
+    // TODO: Move rest of dependencies into Versions.kt and Dependencies.kt
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,7 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/Dependencies.kt
@@ -1,0 +1,13 @@
+import org.gradle.api.artifacts.dsl.DependencyHandler
+import Versions
+
+// Android
+fun DependencyHandler.`androidx-core-ktx` (version:String = Versions.ANDROIDX_CORE_KTX)= "androidx.core:core-ktx:${version}"
+fun DependencyHandler.`androidx-lifecycle-runtime-ktx`(version:String = Versions.ANDROIDX_LIFECYCLE_RUNTIME_KTX) = "androidx.lifecycle:lifecycle-runtime-ktx:${version}"
+
+fun DependencyHandler.`androidx-activity-compose`(version: String = Versions.ANDROIDX_ACTIVITY_COMPOSE) = "androidx.activity:activity-compose:${version}"
+fun DependencyHandler.`androidx-compose-bom`(version: String = Versions.ANDROIDX_COMPOSE_BOM) = "androidx.compose:compose-bom:${version}"
+fun DependencyHandler.`androidx-compose-ui`(version: String = Versions.ANDROIDX_COMPOSE_UI) = "androidx.compose.ui:ui:${version}"
+fun DependencyHandler.`androidx-compose-ui-graphics`(version: String = Versions.ANDROIDX_COMPOSE_UI_GRAPHICS) = "androidx.compose.ui:ui-graphics:${version}"
+fun DependencyHandler.`androidx-compose-ui-tooling-preview`(version: String = Versions.ANDROIDX_COMPOSE_UI_TOOLING_PREVIEW) = "androidx.compose.ui:ui-tooling-preview:${version}"
+fun DependencyHandler.`androidx-compose-material3`(version:String = Versions.ANDROIDX_COMPOSE_MATERIAL3) = "androidx.compose.material3:material3:${version}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -1,0 +1,11 @@
+internal object Versions{
+    const val ANDROIDX_CORE_KTX = "1.9.0"
+    const val ANDROIDX_LIFECYCLE_RUNTIME_KTX = "2.6.1"
+    const val ANDROIDX_ACTIVITY_COMPOSE = "1.7.0"
+    const val ANDROIDX_COMPOSE_BOM= "2023.03.00"
+    const val ANDROIDX_COMPOSE_UI= "+"
+    const val ANDROIDX_COMPOSE_UI_GRAPHICS= "+"
+    const val ANDROIDX_COMPOSE_UI_TOOLING_PREVIEW= "+"
+    const val ANDROIDX_COMPOSE_MATERIAL3= "+"
+    // TODO: Add test dependencies here as well
+}


### PR DESCRIPTION
Move dependencies of gradle modules into `buildSrc`.
Versions for each library is defined in `Versions.kt`. 
Libraries used for each project is defined in `Dependencies.kt`